### PR TITLE
use cache-features=true to avoid duplicate database query for the same data

### DIFF
--- a/app/style/layers.js
+++ b/app/style/layers.js
@@ -15,10 +15,9 @@ function layers(shading, contours) {
       'select geometry, type from osm_waterways')
     .sqlLayer('feature_lines',
       'select geometry, type from osm_feature_lines')
-    .sqlLayer('higwayGlows',
-      'select geometry, type, tracktype, class from osm_roads order by z_order')
-    .sqlLayer('highways',
-      'select geometry, type, tracktype, class from osm_roads order by z_order')
+    .sqlLayer(['higwayGlows', 'highways'],
+      'select geometry, type, tracktype, class from osm_roads order by z_order',
+      {'cache-features': 'true'})
     .sqlLayer('buildings',
       'select geometry, type from osm_buildings')
     .sqlLayer('barrierways',


### PR DESCRIPTION
I've forgot about this cache when writing about caches in Mapnik.