### PR TITLE
#6: render place=locality

### DIFF
--- a/app/style/index.js
+++ b/app/style/index.js
@@ -240,6 +240,16 @@ function generateFreemapStyle(shading = shadingCfg, contours = contoursCfg, hiki
       //   .textSymbolizer({ ...fontDfltWrap }, nameWithEle)
 
     // texts
+    .style('locality_names').doInStyle((style) => {
+      const sizes = { 14: 10, 15: 11, 16: 12, 17: 12, 18: 12, 19: 12 };
+      const opacities = { 14: 0.5, 15: 0.6, 16: 0.65, 17: 0.7, 18: 0.8, 19: 0.9 };
+      for (let z = 14; z < 20; z++) {
+        style.typesRule(z, z, 'locality')
+          .textSymbolizer({ ...fontDflt, fill: '#000000', haloFill: '#000000', 
+          opacity: opacities[z], haloOpacity: 0, haloRadius: 0, 
+          size: sizes[z] }, '[name]'); 
+      }
+    })
     .style('infopoint_names').doInStyle((style) => {
       const fontSizes = { 12: 12, 13: 12, 14: 13, 15: 14, 16: 15 };
       for (let z = 13; z < 20; z++) {
@@ -312,6 +322,7 @@ function generateFreemapStyle(shading = shadingCfg, contours = contoursCfg, hiki
               .typesRule(z, z, 'suburb', 'hamlet')
                 .textSymbolizer({ ...placenamesFontStyle, haloRadius: 1.5, size: 0.5 * sc }, '[name]');
           }
+
         }
       })
     .doInMap((map) => {

--- a/app/style/layers.js
+++ b/app/style/layers.js
@@ -76,6 +76,8 @@ function layers(shading, contours) {
       'select name, type, geometry from osm_buildings')
     .sqlLayer('protected_area_names',
       'select name, geometry from osm_protected_areas')
+    .sqlLayer('locality_names',
+      "select name, type, geometry from osm_places where type in ('locality')")
     .sqlLayer('placenames',
       'select name, type, geometry from osm_places order by z_order desc',
       { clearLabelCache: 'on', bufferSize: 1024 });


### PR DESCRIPTION
localities sa skryvaju za vsetky ostatne vrstvy textov.
viditelne od Z14, postupne sa zvacsuje velkost aj znizuje priehladnost.
trochu sa mi nepaci, ze nazvy chranenych uzemi vyzeraju zrazu velmi drobne.. mozno by sme ich mohli zvyraznit.

<img width="993" alt="screenshot 2019-01-10 at 17 43 53" src="https://user-images.githubusercontent.com/225506/50983468-cffa1580-14ff-11e9-8dfb-3513d118f423.png">
<img width="685" alt="screenshot 2019-01-10 at 17 44 43" src="https://user-images.githubusercontent.com/225506/50983469-cffa1580-14ff-11e9-94df-a47f8ce547e8.png">


