### PR TITLE
change valley names style #36

### DIFF
--- a/style/index.js
+++ b/style/index.js
@@ -289,8 +289,16 @@ function generateFreemapStyle(shading = shadingCfg, contours = contoursCfg, hiki
       .rule({ minZoom: 15 })
         .textSymbolizer({ ...fontDflt, fill: '#3d1d1d', placement: 'line', spacing: 200 }, '[name]')
     .style('feature_line_names')
-      .typesRule(13, 'valley')
-        .textSymbolizer({ ...fontDflt, size: 16, opacity: 0.5, haloOpacity: 0.5, placement: 'line', spacing: 400 }, '[name]') // TODO size by zoom as for placenames
+    .doInStyle((style) => {
+      const opacities = { 14: 0.4, 15: 0.4, 16: 0.35, 17: 0.35, 18: 0.35, 19: 0.35 };
+      const sizes = { 14: 11, 15: 12, 16: 13, 17: 15, 18: 16, 19: 16 };
+      const vallyeText = { ...fontDflt, placement: 'line', repeatDistance: 400,
+        textTransform: 'uppercase', fill: '#000000', haloOpacity: 0, haloRadius: 0 }
+      for (let z = 14; z < 20; z++) {
+        style.typesRule(z, z, 'valley')
+          .textSymbolizer({ ...vallyeText, size: sizes[z], opacity: opacities[z] }, '[name]')
+      }
+    })
     .style('water_line_names')
       .typesRule(12, 'river')
         .textSymbolizer({ ...natureRelatedFontWrap, haloFill: colors.waterLabelHalo, placement: 'line', spacing: 400 }, '[name]')


### PR DESCRIPTION
rendruje sa az od z14, lebo pri z13 to vykreslovalo len bezvyznamne doliny na vyssich ubociach kde neboli ine objekty.
v principe velmi podobny styl ako locality names, ale uppercase.

<img width="735" alt="screenshot 2019-01-11 at 17 34 42" src="https://user-images.githubusercontent.com/225506/51046968-bcb27d00-15c7-11e9-81da-f165e37f28a4.png">
<img width="763" alt="screenshot 2019-01-11 at 17 35 01" src="https://user-images.githubusercontent.com/225506/51046969-bcb27d00-15c7-11e9-8a0b-7e54ecb60c47.png">
<img width="708" alt="screenshot 2019-01-11 at 17 35 12" src="https://user-images.githubusercontent.com/225506/51046970-bd4b1380-15c7-11e9-8ad8-d63287ef11bf.png">
<img width="980" alt="screenshot 2019-01-11 at 17 35 28" src="https://user-images.githubusercontent.com/225506/51046971-bd4b1380-15c7-11e9-95ee-01926ed214fd.png">
