### PR TITLE
resolve #42: Render historic=ruins

### DIFF
--- a/additional.sql
+++ b/additional.sql
@@ -85,5 +85,6 @@ insert into zindex (type) values
 ('waste_disposal'),
 ('lift_gate'),
 ('feeding_place'),
-('game_feedng'),
-('gate');
+('game_feeding'),
+('gate'),
+('ruins');

--- a/images/ruins.svg
+++ b/images/ruins.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" id="svg2" viewBox="0 0 14 14" height="100%" width="100%" version="1.1" sodipodi:docname="castle.svg" inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1881" inkscape:window-height="1051" id="namedview846" showgrid="false" inkscape:pagecheckerboard="true" inkscape:zoom="61.285714" inkscape:cx="7" inkscape:cy="7" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1" inkscape:current-layer="svg2" />
+  <metadata id="metadata8">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id="defs6" />
+  <path style="opacity:0.5;fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 1,1 L 0,2.5 V 3 H 5 V 2.5 L 4,1 Z M 10,1 L 9,2.5 V 3 H 14 V 2.5 L 13,1 Z M 0,4 V 13 H 5 C 5,12 5,10 7,10 C 9,10 9,12 9,13 H 14 V 4 H 9 V 6 H 7 H 5 V 4 Z M 2,6 H 3 V 7 L 2.5,8 L 2,7 Z M 11,6 H 12 V 7 L 11.5,8 L 11,7 Z" id="outline" inkscape:connector-curvature="0" />
+  <path id="path824" d="M 1 1 L 0 2.5 L 0 3 L 5 3 L 5 2.5 L 4 1 L 1 1 z M 10 1 L 9 2.5 L 9 3 L 14 3 L 14 2.5 L 13 1 L 10 1 z M 0 4 L 0 13 L 5 13 C 5 12 5 10 7 10 C 9 10 9 12 9 13 L 14 13 L 14 4 L 9 4 L 9 6 L 7 6 L 5 6 L 5 4 L 0 4 z M 2 6 L 3 6 L 3 7 L 2.5 8 L 2 7 L 2 6 z M 11 6 L 12 6 L 12 7 L 11.5 8 L 11 7 L 11 6 z " style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>

--- a/images/ruins.svg
+++ b/images/ruins.svg
@@ -1,16 +1,62 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" id="svg2" viewBox="0 0 14 14" height="100%" width="100%" version="1.1" sodipodi:docname="castle.svg" inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1881" inkscape:window-height="1051" id="namedview846" showgrid="false" inkscape:pagecheckerboard="true" inkscape:zoom="61.285714" inkscape:cx="7" inkscape:cy="7" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1" inkscape:current-layer="svg2" />
-  <metadata id="metadata8">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   viewBox="0 0 14 14"
+   height="100%"
+   width="100%"
+   version="1.1"
+   sodipodi:docname="ruins.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="778"
+     id="namedview846"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="27.939941"
+     inkscape:cx="0.41984465"
+     inkscape:cy="7.2478445"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <metadata
+     id="metadata8">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs6" />
-  <path style="opacity:0.5;fill:none;fill-opacity:1;stroke:#fffff4;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="M 1,1 L 0,2.5 V 3 H 5 V 2.5 L 4,1 Z M 10,1 L 9,2.5 V 3 H 14 V 2.5 L 13,1 Z M 0,4 V 13 H 5 C 5,12 5,10 7,10 C 9,10 9,12 9,13 H 14 V 4 H 9 V 6 H 7 H 5 V 4 Z M 2,6 H 3 V 7 L 2.5,8 L 2,7 Z M 11,6 H 12 V 7 L 11.5,8 L 11,7 Z" id="outline" inkscape:connector-curvature="0" />
-  <path id="path824" d="M 1 1 L 0 2.5 L 0 3 L 5 3 L 5 2.5 L 4 1 L 1 1 z M 10 1 L 9 2.5 L 9 3 L 14 3 L 14 2.5 L 13 1 L 10 1 z M 0 4 L 0 13 L 5 13 C 5 12 5 10 7 10 C 9 10 9 12 9 13 L 14 13 L 14 4 L 9 4 L 9 6 L 7 6 L 5 6 L 5 4 L 0 4 z M 2 6 L 3 6 L 3 7 L 2.5 8 L 2 7 L 2 6 z M 11 6 L 12 6 L 12 7 L 11.5 8 L 11 7 L 11 6 z " style="fill:#000000;fill-opacity:1;stroke:none" />
+  <defs
+     id="defs6" />
+  <path
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 1.3902641,1.4620437 V 13.306573 H 13.031975 V 7.7088156 H 6.8663304 V 1.4214803 Z"
+     style="opacity:0.5;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.75353861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.9178462px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 1.3902641,1.4620437 V 13.306573 H 13.031975 V 7.7088156 H 6.8663304 V 1.4214803 Z"
+     id="ruins"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/style/index.js
+++ b/style/index.js
@@ -25,6 +25,7 @@ const colors = {
   water: hsl(210, 65, 65),
   waterLabelHalo: hsl(210, 30, 100),
   building: hsl(0, 0, 50),
+  ruin: hsl(0, 0, 60),
   track: hsl(0, 33, 25),
   forest: hsl(120, 45, 78),
   heath: hsl(85, 60, 80),
@@ -117,6 +118,7 @@ const pois = [
   [13, 13, true, true, 'peak', { font: { size: 13, dy: -8 } }],
 
   [14, 15, false, false , 'castle'],
+  [14, 15, false, false , 'ruins'],
   [14, 15, true, true, 'cave_entrance'],
   [14, 15, true, true, 'spring', { font: { fill: hsl(216, 100, 50) } }],
   [14, 15, true, true, 'waterfall', { font: { fill: hsl(216, 100, 50) } }],
@@ -312,6 +314,9 @@ function generateFreemapStyle(
     .style('buildings')
       .rule({ minZoom: 13 })
         .polygonSymbolizer({ fill: colors.building })
+    .style('ruin_polys')
+      .rule({ minZoom: 13 })
+        .polygonSymbolizer({ fill: colors.ruin })
     .style('protected_areas')
       .typesRule(8, 11, 'national_park', 'nature_reserve')
         .lineSymbolizer({ stroke: hsl(120, 100, 31), strokeWidth: 3, strokeDasharray: '25,7', strokeOpacity: 0.8 })

--- a/style/layers.js
+++ b/style/layers.js
@@ -73,6 +73,10 @@ function layers(shading, contours, hikingTrails, bicycleTrails /*, skiTrails*/) 
       'select geometry, type from osm_buildings',
       { minZoom: 13 },
     )
+    .sqlLayer('ruin_polys',
+      'select geometry from osm_ruin_polys',
+      { minZoom: 13 },
+    )
     .sqlLayer('barrierways',
       'select geometry, type from osm_barrierways',
       { minZoom: 16 },
@@ -193,6 +197,8 @@ function layers(shading, contours, hikingTrails, bicycleTrails /*, skiTrails*/) 
         union all select building as type, geometry from osm_place_of_worships
         union all select building as type, geometry from osm_place_of_worship_polys
         union all select type, geometry from osm_transport_points where type = 'bus_stop'
+        union all select 'ruins' as type, geometry from osm_ruins
+        union all select 'ruins' as type, geometry from osm_ruin_polys
         union all select type, geometry from osm_infopoints) as abc left join zindex using (type)
         order by z`,
       { minZoom: 10 },
@@ -207,6 +213,8 @@ function layers(shading, contours, hikingTrails, bicycleTrails /*, skiTrails*/) 
         union all select building as type, geometry, name, null as ele from osm_place_of_worships
         union all select building as type, geometry, name, null as ele from osm_place_of_worship_polys
         union all select type, geometry, name, null as ele from osm_transport_points where type = 'bus_stop'
+        union all select 'ruins' as type, geometry, name, null from osm_ruins
+        union all select 'ruins' as type, geometry, name, null from osm_ruin_polys
         union all select type, geometry, name, ele from osm_infopoints) as abc left join zindex using (type)
         order by z`,
       { minZoom: 10 },


### PR DESCRIPTION
vzdy sa rendruje ikonka.
ak je text, rendruje sa aj ten.
ak je to `way`, rendruje sa aj pod ikonou a textom aj budova (trosku svetlejsie ako `building`).

akurat ikonku som z nudze zatial prevzal z `castle`, lebo mam problem editovat svg na macos-e. jediny  volne dostupny nastroj ktory za nieco stoji je inkscape, lenze ten na macos-e funguje velmi biedne. a ostatne volne dostupne nastroje su velmi slabe.

a treba si pregenerovat data, lebo som musel zmenil [mapping.yml](https://github.com/FreemapSlovakia/freemap-mapnik/commit/9f73521b8d146f20eff2bb4f4b3eafd8f8de0f29)

<img width="933" alt="screenshot 2019-02-10 at 11 20 27" src="https://user-images.githubusercontent.com/225506/52532501-8d0da680-2d26-11e9-9ee9-4d8f4cd42bba.png">
