### PR TITLE
 Fix name for Monument

### DIFF
--- a/legend.js
+++ b/legend.js
@@ -777,7 +777,7 @@ const legend = {
     poi('poi', 'castle', 'castle', 'hrad'),
     poi('poi', 'ruins', 'ruins', 'ruiny'),
 
-    poi('poi', 'monument', 'monument', 'pamätník'),
+    poi('poi', 'monument', 'monument', 'pamätihodnosť'),
     poi('poi', 'memorial', 'memorial', 'pamätník'),
     poi('poi', 'artwork', 'artwork', 'umelecké dielo'),
 

--- a/legend.js
+++ b/legend.js
@@ -777,7 +777,7 @@ const legend = {
     poi('poi', 'castle', 'castle', 'hrad'),
     poi('poi', 'ruins', 'ruins', 'ruiny'),
 
-    poi('poi', 'monument', 'monument', 'pamätihodnosť'),
+    poi('poi', 'monument', 'monument', 'pomník'),
     poi('poi', 'memorial', 'memorial', 'pamätník'),
     poi('poi', 'artwork', 'artwork', 'umelecké dielo'),
 


### PR DESCRIPTION
Change slovak name for Monument from 'pamätník' to 'pamätihodnosť'